### PR TITLE
Stability Improvements

### DIFF
--- a/src/Connection.c
+++ b/src/Connection.c
@@ -506,7 +506,13 @@ int LiStartConnection(PSERVER_INFORMATION serverInfo, PSTREAM_CONFIGURATION stre
 
     Limelog("Starting input stream...");
     ListenerCallbacks.stageStarting(STAGE_INPUT_STREAM_START);
+#ifdef __3DS__
+    PltSetCoreId(1);
+#endif
     err = startInputStream();
+#ifdef __3DS__
+    PltSetCoreId(0);
+#endif
     if (err != 0) {
         Limelog("Input stream start failed: %d\n", err);
         ListenerCallbacks.stageFailed(STAGE_INPUT_STREAM_START, err);

--- a/src/ControlStream.c
+++ b/src/ControlStream.c
@@ -362,7 +362,7 @@ void destroyControlStream(void) {
 
 static void queueFrameInvalidationTuple(uint32_t startFrame, uint32_t endFrame) {
     LC_ASSERT(startFrame <= endFrame);
-    
+
     if (isReferenceFrameInvalidationEnabled()) {
         PQUEUED_FRAME_INVALIDATION_TUPLE qfit;
         qfit = malloc(sizeof(*qfit));
@@ -411,7 +411,7 @@ void connectionSendFrameFecStatus(PSS_FRAME_FEC_STATUS fecStatus) {
     if (!IS_SUNSHINE()) {
         return;
     }
-    
+
     // Queue a frame FEC status message. This is best-effort only.
     PQUEUED_FRAME_FEC_STATUS queuedFecStatus = malloc(sizeof(*queuedFecStatus));
     if (queuedFecStatus != NULL) {
@@ -1286,7 +1286,7 @@ static void lossStatsThreadFunc(void* context) {
                         free(queuedFrameStatus);
                         return;
                     }
-                    
+
                     free(queuedFrameStatus);
                 }
             }
@@ -1314,7 +1314,7 @@ static void lossStatsThreadFunc(void* context) {
     }
     else {
         char* lossStatsPayload;
-        
+
         // Sunshine should use the newer codepath above
         LC_ASSERT(!IS_SUNSHINE());
 
@@ -1490,7 +1490,7 @@ int stopControlStream(void) {
     if (ctlSock != INVALID_SOCKET) {
         shutdownTcpSocket(ctlSock);
     }
-    
+
     PltInterruptThread(&lossStatsThread);
     PltInterruptThread(&requestIdrFrameThread);
     PltInterruptThread(&controlReceiveThread);
@@ -1523,7 +1523,7 @@ int stopControlStream(void) {
         enet_host_destroy(client);
         client = NULL;
     }
-    
+
     if (ctlSock != INVALID_SOCKET) {
         closeSocket(ctlSock);
         ctlSock = INVALID_SOCKET;
@@ -1594,7 +1594,7 @@ int startControlStream(void) {
     if (AppVersionQuad[0] >= 5) {
         ENetAddress address;
         ENetEvent event;
-        
+
         LC_ASSERT(ControlPortNumber != 0);
 
         enet_address_set_address(&address, (struct sockaddr *)&RemoteAddr, RemoteAddrLen);
@@ -1658,9 +1658,14 @@ int startControlStream(void) {
 
         // Ensure the connect verify ACK is sent immediately
         enet_host_flush(client);
-        
+
+#ifndef __3DS__
         // Set the peer timeout to 10 seconds and limit backoff to 2x RTT
         enet_peer_timeout(peer, 2, 10000, 10000);
+#else
+        // Set the peer timeout to 60 seconds and limit backoff to 2x RTT
+        enet_peer_timeout(peer, 2, 30000, 60000);
+#endif
     }
     else {
         // NB: Do NOT use ControlPortNumber here. 47995 is correct for these old versions.

--- a/src/Platform.c
+++ b/src/Platform.c
@@ -93,6 +93,10 @@ void* ThreadProc(void* context) {
     free(ctx);
 #endif
 
+#if defined(__3DS__)
+    threadExit(0);
+#endif
+
 #if defined(LC_WINDOWS) || defined(__vita__) || defined(__WIIU__) || defined(__3DS__)
     return 0;
 #else
@@ -195,6 +199,7 @@ void PltJoinThread(PLT_THREAD* thread) {
     OSJoinThread(&thread->thread, NULL);
 #elif defined(__3DS__)
 	threadJoin(thread->thread, U64_MAX);
+    threadFree(thread->thread);
 #else
     pthread_join(thread->thread, NULL);
 #endif

--- a/src/Platform.c
+++ b/src/Platform.c
@@ -198,7 +198,7 @@ void PltJoinThread(PLT_THREAD* thread) {
 #elif defined(__WIIU__)
     OSJoinThread(&thread->thread, NULL);
 #elif defined(__3DS__)
-	threadJoin(thread->thread, U64_MAX);
+    threadJoin(thread->thread, U64_MAX);
     threadFree(thread->thread);
 #else
     pthread_join(thread->thread, NULL);
@@ -504,7 +504,7 @@ int initializePlatform(void) {
 
     enterLowLatencyMode();
 
-	return 0;
+    return 0;
 }
 
 void cleanupPlatform(void) {


### PR DESCRIPTION
- Pull in stability improvements from enet
- Move the input stream to CPU 1
- Free thread resources after joining
- Increase the control timeout for the 3DS